### PR TITLE
Document encrypted endpoint for accessing the WebUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ git clone https://github.com/openxpki/openxpki-config.git --branch=docker
 $ docker-compose  up 
 ```
 
-This will expose the OpenXPKI WebUI via `http://localhost:8080` (**unencrypted**!) with the sample configuration but without any tokens. Place your keys and certificates into the `ca` directory of the config directory and follow the instructions given in the quickstart tutorial: https://openxpki.readthedocs.io/en/latest/quickstart.html#setup-base-certificates.
+This will expose the OpenXPKI WebUI via `https://localhost:8443` with the sample configuration but without any tokens. Place your keys and certificates into the `ca` directory of the config directory and follow the instructions given in the quickstart tutorial: https://openxpki.readthedocs.io/en/latest/quickstart.html#setup-base-certificates.
 
 ## Prebuilt images
 


### PR DESCRIPTION
With the default config from openxpki-config, localhost:8080 redirects to https://localhost:8080. The docker-compose file routes 8080 to port 80 on the container, and 8443 to port 443 on the container, so https access needs to happen at localhost:8443.

Note:
This caused me some confusion when attempting to follow the quick-start instructions using the docker images. There may be a better way to clarify this, but this is what I think would have helped me.