### PR TITLE
readme: explicitly declare web UI path

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ git clone https://github.com/openxpki/openxpki-config.git --branch=docker
 $ docker-compose  up 
 ```
 
-If you dont provide a TLS certificate for the webserver yourself (see below), the init script creates a self-signed one and exposes the webserver UI on port 8443 (`https://localhost:8443`). The SCEP and RPC interface is available via plain HTTP on port 8080 (`http://localhost:8080`). The system is started with the configuration found in the openxpki-config path, without tokens installed! Place your keys and certificates into the `ca` directory of the config directory and follow the instructions given in the quickstart tutorial: https://openxpki.readthedocs.io/en/latest/quickstart.html#setup-base-certificates.
+If you dont provide a TLS certificate for the webserver yourself (see below), the init script creates a self-signed one and exposes the webserver UI on port 8443 (`https://localhost:8443/openxpki/`). The SCEP and RPC interface is available via plain HTTP on port 8080 (`http://localhost:8080`). The system is started with the configuration found in the openxpki-config path, without tokens installed! Place your keys and certificates into the `ca` directory of the config directory and follow the instructions given in the quickstart tutorial: https://openxpki.readthedocs.io/en/latest/quickstart.html#setup-base-certificates.
 
 ## Prebuilt images
 


### PR DESCRIPTION
Took me some time to figure out that the actual UI is accessible at `/openxpki`.