### PR TITLE
Fix two errors when invoking "docker-compose up" .

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     command: --default-authentication-plugin=mysql_native_password
     volumes:
       - openxpkidb:/var/lib/mysql
-      - ./openxpki-config/contrib/sql/schema-mysql.sql:/docker-entrypoint-initdb.d/schema-mysql.sql
+      - ./openxpki-config/contrib/sql/schema-mysql.sql:/docker-entrypoint-initdb.d/schema-mysql.sql:z
+      - openxpkidbsocket:/var/run/mysqld
     environment:
       MYSQL_DATABASE: openxpki
       MYSQL_USER: openxpki
@@ -19,9 +20,10 @@ services:
     image: whiterabbitsecurity/openxpki3
     command: /usr/bin/openxpkictl start --no-detach
     volumes:
-      - ./openxpki-config:/etc/openxpki
+      - ./openxpki-config:/etc/openxpki:z
       - openxpkilog:/var/log/openxpki
       - openxpkisocket:/var/openxpki/
+      - openxpkidbsocket:/var/run/mysqld
     depends_on:
         - db
 
@@ -33,7 +35,7 @@ services:
       - "8080:80/tcp"
       - "8443:443/tcp"
     volumes:
-      - ./openxpki-config:/etc/openxpki
+      - ./openxpki-config:/etc/openxpki:z
       - openxpkilog:/var/log/openxpki
       - openxpkisocket:/var/openxpki/
     depends_on:
@@ -43,4 +45,4 @@ volumes:
   openxpkidb:
   openxpkisocket:
   openxpkilog:
-
+  openxpkidbsocket:


### PR DESCRIPTION
Hello,

I have fixed two errors when invoking "docker-compose up" on CentOS 7.7.
It would be appreciated it if you could review this patch.

* Append ':z' to the volume to fix the permission denied when SELinux is enabled.

* Add a volume to share the mysqld socket.

Thank you.