### PR TITLE
Added openxpkidownload volume to openxpki-client and openxpki-server

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - openxpkilog:/var/log/openxpki
       - openxpkisocket:/var/openxpki/
       - openxpkidbsocket:/var/run/mysqld/
+      - openxpkidownload:/var/www/download/
       # this will not work on all OS
       - "/etc/timezone:/etc/timezone:ro"
       - "/etc/localtime:/etc/localtime:ro"
@@ -42,6 +43,7 @@ services:
       - openxpkilog:/var/log/openxpki
       - openxpkisocket:/var/openxpki/
       - openxpkidbsocket:/var/run/mysqld/
+      - openxpkidownload:/var/www/download/
     depends_on:
         - openxpki-server
 
@@ -50,4 +52,5 @@ volumes:
   openxpkisocket:
   openxpkidbsocket:
   openxpkilog:
+  openxpkidownload:
 


### PR DESCRIPTION
Currently CRLs and CA-certificates could not be retrieved by clients without the
user interface, as the files were generated to `/var/www/download` on the
`openxpki-server` container, and the webserver in the `openxpki-client` container serves it's own `/var/www/download`, without the generated files in it.

This pull request mounts `/var/www/download/` into a volume (`openxpkidownload`) in
both containers, so that they have the same content in `/var/www/download/`.