### PR TITLE
wip: compatibility with rootless podman and selinux

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,12 @@ services:
   db:
 #    restart: always
     image: mariadb:10
+    security_opt: label=disable
     command: --default-authentication-plugin=mysql_native_password
     volumes:
       - openxpkidb:/var/lib/mysql
       - openxpkidbsocket:/var/run/mysqld/
-      - ./openxpki-config/contrib/sql/schema-mariadb.sql:/docker-entrypoint-initdb.d/schema-mariadb.sql
+      - ./openxpki-config/contrib/sql/schema-mariadb.sql:/docker-entrypoint-initdb.d/schema-mariadb.sql:z
     environment:
       MYSQL_DATABASE: openxpki
       MYSQL_USER: openxpki
@@ -18,9 +19,10 @@ services:
   openxpki-server:
 #    restart: always
     image: whiterabbitsecurity/openxpki3
+    security_opt: label=disable
     command: /usr/bin/openxpkictl start --no-detach
     volumes:
-      - ./openxpki-config:/etc/openxpki
+      - ./openxpki-config:/etc/openxpki:z
       - openxpkilog:/var/log/openxpki
       - openxpkisocket:/var/openxpki/
       - openxpkidbsocket:/var/run/mysqld/
@@ -33,12 +35,13 @@ services:
   openxpki-client:
 #    restart: always
     image: whiterabbitsecurity/openxpki3
+    security_opt: label=disable
     command: /usr/bin/start-apache
     ports:
       - "8080:80/tcp"
       - "8443:443/tcp"
     volumes:
-      - ./openxpki-config:/etc/openxpki
+      - ./openxpki-config:/etc/openxpki:z
       - openxpkilog:/var/log/openxpki
       - openxpkisocket:/var/openxpki/
       - openxpkidbsocket:/var/run/mysqld/


### PR DESCRIPTION
Dears,

thanks for openxpi and the docker setup. I have tried to spin it up on Fedora Kinoite that comes with rootless podman and SELinux.

In such situation, the boot fails for several reasons (my best guesses here):
- [x] SELinux prevents the containers from reading config files at `./openxpki-config/contrib/sql/schema-mariadb.sql` and `./openxpki-config`
- [ ] I suspect a race conditions between the containers to create the /var/run/mysqld folder or the socket in it. If the openxpki containers win this race, then the mariadb container fails with:
~~~
[db]              | 2024-10-18 21:24:11 0 [ERROR] Can't start server : Bind on unix socket: Permission denied
[db]              | 2024-10-18 21:24:11 0 [ERROR] Do you already have another server running on socket: /run/mysqld/mysqld.sock ?
~~~

To solve the first issue, I have added the `:z` flag to the volume mounts and added a flag.

Resources:

- https://docs.podman.io/en/latest/markdown/podman-run.1.html#volume-v-source-volume-host-dir-container-dir-options
- https://github.com/MariaDB/mariadb-docker/issues/363
https://github.com/containers/podman/issues/8216

A current work around is to not rely on the socket, but instead use TCP to connect to the database.