### PR TITLE
Merge some layers and use inline chmod to reduce image size and layers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ ARG OPENXPKI_NOCONFIG=1
 
 RUN apt-get update && \
     apt-get upgrade --assume-yes && \
-    apt-get install --assume-yes gpg libdbd-mariadb-perl libdbd-mysql-perl apache2 nginx wget locales less gettext
+    apt-get install --assume-yes gpg libdbd-mariadb-perl libdbd-mysql-perl apache2 nginx wget locales less gettext && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN rm /etc/locale.gen && \
     (for lang in "en_US" "de_DE"; do echo "$lang.UTF-8 UTF-8" >> /etc/locale.gen; done) && \
@@ -13,36 +15,37 @@ RUN rm /etc/locale.gen && \
 
 RUN wget http://packages.openxpki.org/v3/bookworm/openxpki.sources -O - 2>/dev/null | tee /etc/apt/sources.list.d/openxpki.sources
 RUN wget http://packages.openxpki.org/v3/bookworm/Release.key -O - 2>/dev/null | gpg -o /usr/share/keyrings/openxpki.pgp --dearmor
-RUN apt-get update && apt-get install --assume-yes libopenxpki-perl openxpki-i18n openxpki-cgi-session-driver
-RUN apt-get clean
+RUN apt-get update && \
+    apt-get install --assume-yes libopenxpki-perl openxpki-i18n openxpki-cgi-session-driver && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 # Hack to run rhel/sles configs in this container
-RUN /usr/bin/id -u www-data | xargs /usr/sbin/useradd apache -s /usr/sbin/nologin -b /var/www -g www-data -o -u
-RUN /usr/bin/id -u www-data | xargs /usr/sbin/useradd wwwrun -s /usr/sbin/nologin -b /var/www -g www-data -o -u
+RUN /usr/bin/id -u www-data | xargs /usr/sbin/useradd apache -s /usr/sbin/nologin -b /var/www -g www-data -o -u && \
+    /usr/bin/id -u www-data | xargs /usr/sbin/useradd wwwrun -s /usr/sbin/nologin -b /var/www -g www-data -o -u
 
 # Install clca (config comes from repo)
-RUN wget https://raw.githubusercontent.com/openxpki/clca/master/bin/clca -O /usr/local/bin/clca && chmod 755 /usr/local/bin/clca
+RUN wget https://raw.githubusercontent.com/openxpki/clca/master/bin/clca -O /usr/local/bin/clca && \
+    chmod 755 /usr/local/bin/clca
 
 ENV LANG=en_US.UTF-8 LANGUAGE=en_US:en LC_ALL=en_US.UTF-8
 VOLUME /etc/openxpki
 
 # Apache
-RUN a2dissite 000-default; a2disconf javascript-common localized-error-pages security serve-cgi-bin other-vhosts-access-log
-RUN a2enmod headers macro proxy proxy_http rewrite ssl
-RUN echo "ErrorLog /proc/self/fd/2" > /etc/apache2/conf-enabled/log2stderr.conf
+RUN a2dissite 000-default && \
+    a2disconf javascript-common localized-error-pages security serve-cgi-bin other-vhosts-access-log && \
+    a2enmod headers macro proxy proxy_http rewrite ssl && \
+    echo "ErrorLog /proc/self/fd/2" > /etc/apache2/conf-enabled/log2stderr.conf
 
 # nginx
-RUN rm /etc/nginx/sites-enabled/default
-RUN echo "error_log /dev/stderr info;" > /etc/nginx/modules-enabled/error-log-stdout.conf
-RUN echo "http { access_log /dev/stdout; }" > /etc/nginx/conf.d/access-log-stdout
+RUN rm /etc/nginx/sites-enabled/default && \
+    echo "error_log /dev/stderr info;" > /etc/nginx/modules-enabled/error-log-stdout.conf && \
+    echo "http { access_log /dev/stdout; }" > /etc/nginx/conf.d/access-log-stdout
 
 # Scripts
-COPY bin/setup-cert.sh /usr/bin/setup-cert
-RUN chmod +x /usr/bin/setup-cert
-COPY bin/start-webserver.sh /usr/bin/start-webserver
-RUN chmod +x /usr/bin/start-webserver
-COPY bin/update-i18n.sh /usr/bin/update-i18n
-RUN chmod +x /usr/bin/update-i18n
+COPY --chmod=755 bin/setup-cert.sh /usr/bin/setup-cert
+COPY --chmod=755 bin/start-webserver.sh /usr/bin/start-webserver
+COPY --chmod=755 bin/update-i18n.sh /usr/bin/update-i18n
 
 # The order here is important
 RUN mkdir -m755 /run/openxpkid /run/openxpki-clientd && \
@@ -54,6 +57,7 @@ RUN mkdir -p -m750 /var/log/openxpki-server /var/log/openxpki-client && \
     chown openxpki:pkiadm /var/log/openxpki-server && \
     chown openxpkiclient:pkiadm /var/log/openxpki-client
 VOLUME /var/log/openxpki-server /var/log/openxpki-client
+
 WORKDIR /var/log/
 
 RUN mkdir -p -m755 /var/www/download && \
@@ -65,3 +69,4 @@ RUN mkdir -p -m755 /var/www/static/_global/ && cp /usr/share/doc/libopenxpki-per
 CMD ["/usr/bin/openxpkictl","start","server","--no-detach"]
 
 EXPOSE 80 443
+


### PR DESCRIPTION
* merge consecutive RUN statements, if the belong to the same feature
* clear apt cache after each setup step
* use inline --chmod for COPY steps

This reduces the final image by 9 layers and about 20MB compressed size withuht functional changes.

----

**Comparison of `docker history` for both images:**

| CREATED BY                                     | ID (orig)    | SIZE (orig) | ID (red)     | SIZE (red) |
|------------------------------------------------|--------------|-------------|--------------|------------|
| /bin/sh -c #(nop) EXPOSE 80 443                | e30dd53c1f1b | 0B          | 2133ebe85ced | 0B         |
| /bin/sh -c #(nop) CMD ["/usr/bin/openxpkic...  | &lt;missing> | 0B          | &lt;missing> | 0B         |
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | &lt;missing> | 5.63kB      | &lt;missing> | 5.62 kB    |
| /bin/sh -c #(nop) VOLUME /var/www/download     | 953dadccae04 | 0B          | ae515104e03d | 0B         |
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | &lt;missing> | 3.07kB      | &lt;missing> | 3.07kB     |
| /bin/sh -c #(nop) WORKDIR /var/log/            | be42f81f25d3 | 0B          | 905974a1fcef | 0B         |
| /bin/sh -c #(nop) VOLUME /var/log/openxpki...  | &lt;missing> | 0B          | &lt;missing> | 0B         |
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | &lt;missing> | 2.56kB      | &lt;missing> | 2.56kB     |
| /bin/sh -c #(nop) VOLUME /run/openxpkid /r...  | 32724467e995 | 0B          | 95ea01205edb | 0B         |
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | &lt;missing> | 2.56kB      | &lt;missing> | 2.56kB     |
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | 9c65b1199618 | 2.56kB      | --           | --         |
| /bin/sh -c #(nop) COPY file:f46f91712095eb...  | f43959311425 | 3.07kB      | 394a3134038f | 3.07kB     |
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | a627406079e2 | 2.56kB      | --           | --         |
| /bin/sh -c #(nop) COPY file:67974057a5b181...  | 86315ec6a47d | 6.14kB      | da5836cc73ed | 6.14kB     |  
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | 0c8c8736064d | 2.56kB      | --           | --         |
| /bin/sh -c #(nop) COPY file:be239d5e97f3ec...  | e08636d9989a | 7.17kB      | eefe7fe71951 | 7.17kB     |  
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | fba788433710 | 4.1kB       | --           | --         |
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | 59527cfd1a1b | 4.1kB       | --           | --         | 
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | 7fd44c1d4435 | 3.58kB      | 445666cf8208 | **6.66 kB**    |  
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | fd7dbc552bfa | 4.1kB       | --           | --         |
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | 15ba2c8dd4b7 | 13.8kB      | --           | --         |
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | d6fb34b9af93 | 17.4kB      | e1340e83fc0f | **28.2 kB**    |  
| /bin/sh -c #(nop) VOLUME /etc/openxpki         | 8a6a75224d70 | 0B          | 90b00a93890c | 0B         |  
| /bin/sh -c #(nop) ENV LANG=en_US.UTF-8 LAN...  | &lt;missing> | 0B          | &lt;missing> | 0B         |
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | &lt;missing> | 50.7kB      | &lt;missing> | 50.7 kB    |
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | eaffeb09325a | 9.22kB      | 7c790b466b76 | 9.22 kB    |  
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | 147d29c28b97 | 8.7kB       | --           | --         |
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | 439f7cd543e2 | 5.12kB      | --           | --         |
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | 079c7928d947 | 378MB       | 745ea78437b3 | 378 MB     |  
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | 268e363b50db | 5.12kB      | 9784a6bb4de1 | 5.12 kB    |  
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | 31574b1184b9 | 4.1kB       | e2522367dd82 | 4.1 kB     |  
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | d0f49c13702b | 5.21MB      | 074f07eef666 | 5.21 MB    |  
| \|2 DEBIAN_FRONTEND=noninteractive OPENXPKI... | 53af8ba62add | 202MB       | c28873d198ba | **182 MB**     |  
| /bin/sh -c #(nop) ARG DEBIAN_FRONTEND OPEN...  | b3a422523a11 | 0B          | b3a422523a11 | 0B         |  
| /bin/sh -c #(nop) ARG DEBIAN_FRONTEND          | &lt;missing> | 0B          | &lt;missing> | 0B         |
| # debian.sh --arch 'amd64' out/ 'bookworm'...  | &lt;missing> | 121MB       | &lt;missing> | 121MB      |

**Comparison of compressed size reported by `docker images`:**

| REPOSITORY         | TAG      | IMAGE ID     | SIZE   |
|--------------------|----------|--------------|--------|
| localhost/openxpki | reduced  | 7e681aa6f2f3 | 687 MB |
| localhost/openxpki | original | cbd901c12d87 | 707 MB |

(* actually built and tested with `podman`, but the results should be equally valid)